### PR TITLE
Policy config for updating default audio device

### DIFF
--- a/AudiosAmigo.Windows/Policy/IPolicyConfig.cs
+++ b/AudiosAmigo.Windows/Policy/IPolicyConfig.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using NAudio.CoreAudioApi;
+
+namespace AudiosAmigo.Windows.Policy
+{
+    public interface IPolicyConfig
+    {
+        int GetMixFormat(string deviceName, IntPtr format);
+
+        int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format);
+
+        int ResetDeviceFormat(string deviceName);
+
+        int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat);
+
+        int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod);
+
+        int SetProcessingPeriod(string deviceName, IntPtr period);
+
+        int GetShareMode(string deviceName, IntPtr mode);
+
+        int SetShareMode(string deviceName, IntPtr mode);
+
+        int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+        int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+        int SetDefaultEndpoint(string deviceName, Role role);
+
+        int SetEndpointVisibility(string deviceName, bool isVisible);
+    }
+}

--- a/AudiosAmigo.Windows/Policy/PolicyConfig.cs
+++ b/AudiosAmigo.Windows/Policy/PolicyConfig.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace AudiosAmigo.Windows.Policy
+{
+    public class PolicyConfig : IPolicyConfig
+    {
+        private readonly IPolicyConfig _config;
+
+        [ComImport, Guid("870AF99C-171D-4F9E-AF0D-E63DF40C2BC9")]
+        internal class PolicyConfigClient
+        {
+        }
+
+        public PolicyConfig()
+        {
+            var config = new PolicyConfigClient();
+            if (WindowsVistaPolicyConfig.IsIWindowsVistaPolicyConfig(config))
+            {
+                _config = new WindowsVistaPolicyConfig(config);
+            }
+            else if (Windows7PolicyConfig.IsIWindows7PolicyConfig(config))
+            {
+                _config = new Windows7PolicyConfig(config);
+            }
+            else if (Windows10PolicyConfig.IsIWindows10PolicyConfig(config))
+            {
+                _config = new Windows10PolicyConfig(config);
+            }
+        }
+
+        public int GetMixFormat(string deviceName, IntPtr format) =>
+            _config.GetMixFormat(deviceName, format);
+        
+        public int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format) =>
+            _config.GetDeviceFormat(deviceName, isDefault, format);
+        
+        public int ResetDeviceFormat(string deviceName) =>
+            _config.ResetDeviceFormat(deviceName);
+        
+        public int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat) =>
+            _config.SetDeviceFormat(deviceName, endpointFormat, mixFormat);
+        
+        public int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod) =>
+            _config.GetProcessingPeriod(deviceName, isDefault, defaultPeriod, minimumPeriod);
+        
+        public int SetProcessingPeriod(string deviceName, IntPtr period) =>
+            _config.SetProcessingPeriod(deviceName, period);
+        
+        public int GetShareMode(string deviceName, IntPtr mode) =>
+            _config.GetShareMode(deviceName, mode);
+        
+        public int SetShareMode(string deviceName, IntPtr mode) =>
+            _config.SetShareMode(deviceName, mode);
+        
+        public int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.GetPropertyValue(deviceName, isFxStore, key, variant);
+        
+        public int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.SetPropertyValue(deviceName, isFxStore, key, variant);
+        
+        public int SetDefaultEndpoint(string deviceName, Role role) =>
+            _config.SetDefaultEndpoint(deviceName, role);
+        
+        public int SetEndpointVisibility(string deviceName, bool isVisible) =>
+            _config.SetEndpointVisibility(deviceName, isVisible);
+    }
+}

--- a/AudiosAmigo.Windows/Policy/Windows10PolicyConfig.cs
+++ b/AudiosAmigo.Windows/Policy/Windows10PolicyConfig.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace AudiosAmigo.Windows.Policy
+{
+    internal class Windows10PolicyConfig : IPolicyConfig
+    {
+        [Guid("00000000-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        internal interface IWindows10PolicyConfig
+        {
+            int GetMixFormat(string deviceName, IntPtr format);
+
+            int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format);
+
+            int ResetDeviceFormat(string deviceName);
+
+            int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat);
+
+            int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod);
+
+            int SetProcessingPeriod(string deviceName, IntPtr period);
+
+            int GetShareMode(string deviceName, IntPtr mode);
+
+            int SetShareMode(string deviceName, IntPtr mode);
+
+            int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetDefaultEndpoint(string deviceName, Role role);
+
+            int SetEndpointVisibility(string deviceName, bool bVisible);
+        }
+    
+        private readonly IWindows10PolicyConfig _config;
+
+        internal static bool IsIWindows10PolicyConfig(object config) => config is IWindows10PolicyConfig;
+
+        internal Windows10PolicyConfig(object config)
+        {
+            _config = (IWindows10PolicyConfig) config;
+        }
+
+        public int GetMixFormat(string deviceName, IntPtr format) =>
+            _config.GetMixFormat(deviceName, format);
+
+        public int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format) =>
+            _config.GetDeviceFormat(deviceName, isDefault, format);
+
+        public int ResetDeviceFormat(string deviceName) =>
+            _config.ResetDeviceFormat(deviceName);
+
+        public int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat) =>
+            _config.SetDeviceFormat(deviceName, endpointFormat, mixFormat);
+
+        public int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod) =>
+            _config.GetProcessingPeriod(deviceName, isDefault, defaultPeriod, minimumPeriod);
+
+        public int SetProcessingPeriod(string deviceName, IntPtr period) =>
+            _config.SetProcessingPeriod(deviceName, period);
+
+        public int GetShareMode(string deviceName, IntPtr mode) =>
+            _config.GetShareMode(deviceName, mode);
+
+        public int SetShareMode(string deviceName, IntPtr mode) =>
+            _config.SetShareMode(deviceName, mode);
+
+        public int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.GetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.SetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetDefaultEndpoint(string deviceName, Role role) =>
+            _config.SetDefaultEndpoint(deviceName, role);
+
+        public int SetEndpointVisibility(string deviceName, bool isVisible) =>
+            _config.SetEndpointVisibility(deviceName, isVisible);
+    }
+}

--- a/AudiosAmigo.Windows/Policy/Windows7PolicyConfig.cs
+++ b/AudiosAmigo.Windows/Policy/Windows7PolicyConfig.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace AudiosAmigo.Windows.Policy
+{
+    internal class Windows7PolicyConfig : IPolicyConfig
+    {
+        [Guid("F8679F50-850A-41CF-9C72-430F290290C8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        internal interface IWindows7PolicyConfig
+        {
+            int GetMixFormat(string deviceName, IntPtr format);
+
+            int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format);
+
+            int ResetDeviceFormat(string deviceName);
+
+            int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat);
+
+            int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod);
+
+            int SetProcessingPeriod(string deviceName, IntPtr period);
+
+            int GetShareMode(string deviceName, IntPtr mode);
+
+            int SetShareMode(string deviceName, IntPtr mode);
+
+            int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetDefaultEndpoint(string deviceName, Role role);
+
+            int SetEndpointVisibility(string deviceName, bool bVisible);
+        }
+
+        private readonly IWindows7PolicyConfig _config;
+
+        internal static bool IsIWindows7PolicyConfig(object config) => config is IWindows7PolicyConfig;
+
+        internal Windows7PolicyConfig(object config)
+        {
+            _config = (IWindows7PolicyConfig)config;
+        }
+
+        public int GetMixFormat(string deviceName, IntPtr format) =>
+            _config.GetMixFormat(deviceName, format);
+
+        public int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format) =>
+            _config.GetDeviceFormat(deviceName, isDefault, format);
+
+        public int ResetDeviceFormat(string deviceName) =>
+            _config.ResetDeviceFormat(deviceName);
+
+        public int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat) =>
+            _config.SetDeviceFormat(deviceName, endpointFormat, mixFormat);
+
+        public int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod) =>
+            _config.GetProcessingPeriod(deviceName, isDefault, defaultPeriod, minimumPeriod);
+
+        public int SetProcessingPeriod(string deviceName, IntPtr period) =>
+            _config.SetProcessingPeriod(deviceName, period);
+
+        public int GetShareMode(string deviceName, IntPtr mode) =>
+            _config.GetShareMode(deviceName, mode);
+
+        public int SetShareMode(string deviceName, IntPtr mode) =>
+            _config.SetShareMode(deviceName, mode);
+
+        public int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.GetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.SetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetDefaultEndpoint(string deviceName, Role role) =>
+            _config.SetDefaultEndpoint(deviceName, role);
+
+        public int SetEndpointVisibility(string deviceName, bool isVisible) =>
+            _config.SetEndpointVisibility(deviceName, isVisible);
+    }
+}

--- a/AudiosAmigo.Windows/Policy/WindowsVistaPolicyConfig.cs
+++ b/AudiosAmigo.Windows/Policy/WindowsVistaPolicyConfig.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace AudiosAmigo.Windows.Policy
+{
+    internal class WindowsVistaPolicyConfig : IPolicyConfig
+    {
+        [Guid("568B9108-44BF-40B4-9006-86AFE5B5A620"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        internal interface IWindowsVistaPolicyConfig
+        {
+            int GetMixFormat(string deviceName, IntPtr format);
+
+            int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format);
+
+            int ResetDeviceFormat(string deviceName);
+
+            int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat);
+
+            int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod);
+
+            int SetProcessingPeriod(string deviceName, IntPtr period);
+
+            int GetShareMode(string deviceName, IntPtr mode);
+
+            int SetShareMode(string deviceName, IntPtr mode);
+
+            int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant);
+
+            int SetDefaultEndpoint(string deviceName, Role role);
+
+            int SetEndpointVisibility(string deviceName, bool bVisible);
+        }
+
+        private readonly IWindowsVistaPolicyConfig _config;
+
+        internal static bool IsIWindowsVistaPolicyConfig(object config) => config is IWindowsVistaPolicyConfig;
+
+        internal WindowsVistaPolicyConfig(object config)
+        {
+            _config = (IWindowsVistaPolicyConfig)config;
+        }
+
+        public int GetMixFormat(string deviceName, IntPtr format) =>
+            _config.GetMixFormat(deviceName, format);
+
+        public int GetDeviceFormat(string deviceName, bool isDefault, IntPtr format) =>
+            _config.GetDeviceFormat(deviceName, isDefault, format);
+
+        public int ResetDeviceFormat(string deviceName) =>
+            _config.ResetDeviceFormat(deviceName);
+
+        public int SetDeviceFormat(string deviceName, IntPtr endpointFormat, IntPtr mixFormat) =>
+            _config.SetDeviceFormat(deviceName, endpointFormat, mixFormat);
+
+        public int GetProcessingPeriod(string deviceName, bool isDefault, IntPtr defaultPeriod, IntPtr minimumPeriod) =>
+            _config.GetProcessingPeriod(deviceName, isDefault, defaultPeriod, minimumPeriod);
+
+        public int SetProcessingPeriod(string deviceName, IntPtr period) =>
+            _config.SetProcessingPeriod(deviceName, period);
+
+        public int GetShareMode(string deviceName, IntPtr mode) =>
+            _config.GetShareMode(deviceName, mode);
+
+        public int SetShareMode(string deviceName, IntPtr mode) =>
+            _config.SetShareMode(deviceName, mode);
+
+        public int GetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.GetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetPropertyValue(string deviceName, bool isFxStore, IntPtr key, IntPtr variant) =>
+            _config.SetPropertyValue(deviceName, isFxStore, key, variant);
+
+        public int SetDefaultEndpoint(string deviceName, Role role) =>
+            _config.SetDefaultEndpoint(deviceName, role);
+
+        public int SetEndpointVisibility(string deviceName, bool isVisible) =>
+            _config.SetEndpointVisibility(deviceName, isVisible);
+    }
+}


### PR DESCRIPTION
Because this is not a supported com operation, Windows is not liable for changing the GUID in between windows implementations. Because of this, the PolicyConfig option has a different location on different versions of windows, and has to be declared in different ways. 

This could have been made a compile time option, however, it is more simple to locate the correct GUID at run-time than it is to compile a different executable for every operating system.