### PR TITLE
Dispose of network elements properly 

### DIFF
--- a/AudiosAmigo.Droid/ConnectionInformation.cs
+++ b/AudiosAmigo.Droid/ConnectionInformation.cs
@@ -51,9 +51,7 @@ namespace AudiosAmigo.Droid
             searchListView.Adapter = searchAdapter;
 
             var searchSet = new HashSet<Java.Lang.String>();
-            UdpUtil.ReceivePortInfo(Constants.ClientBroadcastListenerPort)
-                .ObserveOn(NewThreadScheduler.Default)
-                .SubscribeOn(NewThreadScheduler.Default)
+            var udpSubscription = UdpUtil.ReceivePortInfo(Constants.ClientBroadcastListenerPort)
                 .Select(endpoint => new Java.Lang.String($"{endpoint.Address}:{endpoint.Port}"))
                 .Subscribe(session => activity.RunOnUiThread(() =>
                 {
@@ -186,6 +184,7 @@ namespace AudiosAmigo.Droid
 
             return observableConnect.Select(pressed =>
             {
+                udpSubscription.Dispose();
                 if (passwordLoaded)
                 {
                     return Tuple.Create(ip.Text, int.Parse(port.Text), loadedHash);


### PR DESCRIPTION
When creating network listeners in an observable, the returned disposable was not cleaning up the implementation of the observable.  This is now fixed.

An `async` task now handles the listener such the methods which create the observables no longer block. This also means they do not have to be subscribed to on a different thread explicitly. 