### PR TITLE
Refactor droid to use builder classes

### DIFF
--- a/AudiosAmigo.Droid/AudioDeviceVolumeSlider.cs
+++ b/AudiosAmigo.Droid/AudioDeviceVolumeSlider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Reactive.Linq;
-using Android.Content;
-using Android.Graphics;
 using Android.Views;
 
 namespace AudiosAmigo.Droid
@@ -14,19 +12,17 @@ namespace AudiosAmigo.Droid
 
         public AudioDeviceState State { get; private set; }
 
-        public AudioDeviceVolumeSlider(
-            Context context,
-            AudioDeviceState device,
-            int width, int height, Bitmap image)
+        public AudioDeviceVolumeSlider(AudioDeviceState device, VolumeSlider slider)
         {
             State = device;
-            _slider = new VolumeSlider(context, device.Volume, device.Mute, width, height, image);
+            _slider = slider;
+            Update(State);
         }
 
         public void Update(AudioDeviceState device)
         {
-            _slider.SetVolume(device.Volume);
-            _slider.SetMute(device.Mute);
+            _slider.Volume = device.Volume;
+            _slider.Mute = device.Mute;
         }
 
         public IDisposable Subscribe(IObserver<AudioDeviceState> observer)

--- a/AudiosAmigo.Droid/AudioProcessVolumeSlider.cs
+++ b/AudiosAmigo.Droid/AudioProcessVolumeSlider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Reactive.Linq;
-using Android.Content;
-using Android.Graphics;
 using Android.Views;
 
 namespace AudiosAmigo.Droid
@@ -12,26 +10,24 @@ namespace AudiosAmigo.Droid
 
         private readonly VolumeSlider _slider;
 
-        private AudioProcessState _state;
-        
-        public AudioProcessVolumeSlider(
-            Context context,
-            AudioProcessState process,
-            int width, int height, Bitmap image)
+        public AudioProcessState State { get; private set; }
+
+        public AudioProcessVolumeSlider(AudioProcessState process, VolumeSlider slider)
         {
-            _state = process;
-            _slider = new VolumeSlider(context, process.Volume, process.Mute, width, height, image);
+            State = process;
+            _slider = slider;
+            Update(State);
         }
 
         public void Update(AudioProcessState process)
         {
-            _slider.SetVolume(process.Volume);
-            _slider.SetMute(process.Mute);
+            _slider.Volume = process.Volume;
+            _slider.Mute = process.Mute;
         }
 
         public IDisposable Subscribe(IObserver<AudioProcessState> observer)
         {
-            return _slider.Select(tuple => _state = _state.SetAudio(tuple.Item1, tuple.Item2))
+            return _slider.Select(tuple => State = State.SetAudio(tuple.Item1, tuple.Item2))
                 .Subscribe(observer);
         }
     }

--- a/AudiosAmigo.Droid/AudiosAmigo.Droid.csproj
+++ b/AudiosAmigo.Droid/AudiosAmigo.Droid.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AudioDeviceController.cs" />
     <Compile Include="AudioProcessVolumeSlider.cs" />
     <Compile Include="ConnectionInformation.cs" />
+    <Compile Include="DeviceSelector.cs" />
     <Compile Include="MainActivity.cs">
       <LastGenOutput>MainActivity1.cs</LastGenOutput>
     </Compile>

--- a/AudiosAmigo.Droid/DeviceSelector.cs
+++ b/AudiosAmigo.Droid/DeviceSelector.cs
@@ -1,0 +1,48 @@
+using System;
+using Android.Graphics;
+using Android.Views;
+using Android.Widget;
+using AudiosAmigo.Droid.Observables;
+
+namespace AudiosAmigo.Droid
+{
+    public class DeviceSelector : IObservable<bool>
+    {
+        public class Builder
+        {
+            private readonly LayoutInflater _inflater;
+
+            private readonly int _width;
+
+            private readonly int _height;
+
+            public Builder(LayoutInflater inflater, int width, int height)
+            {
+                _inflater = inflater;
+                _width = width;
+                _height = height;
+            }
+
+            public DeviceSelector Build(Bitmap image)
+            {
+                var imageButton = (ImageButton)_inflater.Inflate(Resource.Layout.device_selector, null);
+                imageButton.SetImageBitmap(Bitmap.CreateScaledBitmap(image, _width, _height, true));
+                return new DeviceSelector(imageButton);
+            }
+        }
+
+        public View Parent => _imageButton;
+
+        private readonly ImageButton _imageButton;
+        
+        private DeviceSelector(ImageButton imageButton)
+        {
+            _imageButton = imageButton;
+        }
+
+        public IDisposable Subscribe(IObserver<bool> observer)
+        {
+            return new ObservableClickListener(_imageButton).Subscribe(observer);
+        }
+    }
+}

--- a/AudiosAmigo.Droid/Resources/layout/Main.axml
+++ b/AudiosAmigo.Droid/Resources/layout/Main.axml
@@ -15,7 +15,8 @@
             android:layout_height="match_parent"
             android:layout_width="0dp"
             android:layout_weight=".20"
-            android:background="@drawable/bgmain">
+            android:background="@drawable/bgmain"
+            android:fadeScrollbars="false">
             <LinearLayout
                 android:id="@+id/device_container"
                 android:layout_width="match_parent"
@@ -29,7 +30,8 @@
             android:layout_height="match_parent"
             android:layout_width="0dp"
             android:layout_weight=".80"
-            android:background="@drawable/bgmain">
+            android:background="@drawable/bgmain"
+            android:fadeScrollbars="false">
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"

--- a/AudiosAmigo.Droid/VolumeSlider.cs
+++ b/AudiosAmigo.Droid/VolumeSlider.cs
@@ -1,117 +1,135 @@
 using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Android.Content;
 using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using Android.Widget;
 using AudiosAmigo.Droid.Observables;
 using AudiosAmigo.Droid.Views;
+using static Android.Views.ViewGroup.LayoutParams;
 
 namespace AudiosAmigo.Droid
 {
     public class VolumeSlider : IObservable<Tuple<float, bool>>
     {
-        public LinearLayout Parent { get; }
+        public class Builder
+        {
+            private readonly LayoutInflater _inflater;
 
-        private readonly SupressSubject<Tuple<float, bool>> _subject = 
-            new SupressSubject<Tuple<float, bool>>(new Subject<Tuple<float, bool>>());
+            private readonly Vibrator _vibrator;
 
-        private readonly VerticalSeekBar _seekBar;
+            private readonly int _width;
+
+            private readonly int _height;
+
+            private readonly Bitmap _mute;
+
+            public Builder(
+                LayoutInflater inflater,
+                Vibrator vibrator,
+                int width, int height,
+                Bitmap mute)
+            {
+                _inflater = inflater;
+                _vibrator = vibrator;
+                _width = width;
+                _height = height;
+                _mute = Bitmap.CreateScaledBitmap(mute, _width, _width, true);
+            }
+
+            public VolumeSlider Build(Bitmap icon)
+            {
+                var layout = (LinearLayout)_inflater.Inflate(Resource.Layout.volume_slider, null);
+                layout.LayoutParameters = new LinearLayout.LayoutParams(WrapContent, WrapContent)
+                {
+                    Height = _height,
+                    Width = _width
+                };
+
+                var imageButton = layout.FindViewById<ImageButton>(Resource.Id.process_image);
+                imageButton.LayoutParameters = new LinearLayout.LayoutParams(WrapContent, WrapContent)
+                {
+                    Height = _width,
+                    Width = _width
+                };
+
+                var seekBar = layout.FindViewById<VerticalSeekBar>(Resource.Id.seek_bar);
+                seekBar.LayoutParameters = new LinearLayout.LayoutParams(WrapContent, WrapContent)
+                {
+                    Height = _height - _width - _width / 2,
+                    Width = _width
+                };
+                seekBar.Vibrator = _vibrator;
+                seekBar.Max = 100;
+
+                var iconScaled = Bitmap.CreateScaledBitmap(icon, _width, _width, true);
+
+                var muteIcon = Bitmap.CreateBitmap(_width, _width, _mute.GetConfig());
+                var canvas = new Canvas(muteIcon);
+                canvas.DrawBitmap(iconScaled, new Matrix(), null);
+                canvas.DrawBitmap(_mute, 0, 0, null);
+
+                return new VolumeSlider(layout, imageButton, seekBar, iconScaled, muteIcon);
+            }
+        }
+
+        public View Parent { get; }
+
+        public float Volume
+        {
+            get { return _seekBar.Progress / 100f; }
+            set
+            {
+                _subject.Suppress(1000);
+                _seekBar.Progress = (int)(value * 100);
+            }
+        }
+
+        public bool Mute
+        {
+            get { return _isMuted; }
+            set
+            {
+                _subject.Suppress(1000);
+                if (value != _isMuted)
+                {
+                    _imageButton.PerformClick();
+                }
+            }
+        }
 
         private readonly ImageButton _imageButton;
 
-        private readonly Bitmap _normalImage;
-
-        private readonly Bitmap _muteImage;
+        private readonly SeekBar _seekBar;
 
         private bool _isMuted;
 
-        public VolumeSlider(
-            Context context,
-            float volume, bool mute,
-            int width, int height, Bitmap image)
+        private readonly SupressSubject<Tuple<float, bool>> _subject =
+            new SupressSubject<Tuple<float, bool>>(new Subject<Tuple<float, bool>>());
+
+        private VolumeSlider(
+            LinearLayout parent,
+            ImageButton imageButton,
+            SeekBar seekBar,
+            Bitmap normalImage,
+            Bitmap muteImage)
         {
-            var inflater = (LayoutInflater)context.GetSystemService(Context.LayoutInflaterService);
-            var vibrator = (Vibrator)context.GetSystemService(Context.VibratorService);
-            Parent = (LinearLayout)inflater.Inflate(Resource.Layout.volume_slider, null);
-            const int wc = ViewGroup.LayoutParams.WrapContent;
-            Parent.LayoutParameters = new LinearLayout.LayoutParams(wc, wc)
-            {
-                Height = height,
-                Width = width
-            };
+            Parent = parent;
+            _imageButton = imageButton;
+            _seekBar = seekBar;
 
-            _imageButton = Parent.FindViewById<ImageButton>(Resource.Id.process_image);
-            _imageButton.LayoutParameters = new LinearLayout.LayoutParams(wc, wc)
-            {
-                Height = width,
-                Width = width
-            };
-
-            _normalImage = Bitmap.CreateScaledBitmap(image, width, width, true);
-
-            _isMuted = mute;
-            var muteDefault = Bitmap.CreateScaledBitmap(
-                BitmapFactory.DecodeResource(context.Resources, Resource.Drawable.muteblue), 
-                width, width, true);
-
-            _muteImage = Bitmap.CreateBitmap(muteDefault.Width, muteDefault.Height, muteDefault.GetConfig());
-            var canvas = new Canvas(_muteImage);
-            canvas.DrawBitmap(_normalImage, new Matrix(), null);
-            canvas.DrawBitmap(muteDefault, 0, 0, null);
-
-            SetMute(mute);
-
-            _seekBar = Parent.FindViewById<VerticalSeekBar>(Resource.Id.seek_bar);
-            _seekBar.LayoutParameters = new LinearLayout.LayoutParams(wc, wc)
-            {
-                Height = height - width - width / 2,
-                Width = width
-            };
-            _seekBar.Max = 100;
-            _seekBar.Progress = (int) (volume*100);
-
-            var seekbarListener = new ObservableSeekBarListener(_seekBar);
-            var volumeStream = seekbarListener
-                .Select(progress => progress / 100f)
-                .StartWith(volume);
-
+            var volumeStream = new ObservableSeekBarListener(_seekBar)
+                .Select(progress => progress/100f)
+                .StartWith(0);
             var muteStream = new ObservableClickListener(_imageButton)
-                .Scan(mute, (last, _) => _isMuted = !last)
-                .StartWith(mute);
+                .Scan(_isMuted, (last, _) => _isMuted = !last)
+                .StartWith(_isMuted);
+            muteStream.Subscribe(mute => _imageButton.SetImageBitmap(mute ? muteImage : normalImage));
 
-            muteStream.Subscribe(m => _imageButton.SetImageBitmap(m ? _muteImage : _normalImage));
-
-//      if (Settings.System.GetInt(context.ContentResolver, Settings.System.HapticFeedbackEnabled, 0) != 0)
-//      {
-            _seekBar.Vibrator = vibrator;
-            muteStream.Subscribe(_ =>
-            {
-                vibrator.Vibrate(50);
-            });
-//      }
-
-            _subject.Suppress(1000);
-            volumeStream.CombineLatest(muteStream, Tuple.Create)
+            volumeStream.CombineLatest(muteStream, Tuple.Create).Skip(1)
                 .Sample(TimeSpan.FromMilliseconds(10))
                 .Subscribe(_subject.OnNext);
-        }
-
-        public void SetVolume(float volume)
-        {
-            _subject.Suppress(1000);
-            _seekBar.Progress = (int)(volume * 100);
-        }
-
-        public void SetMute(bool mute)
-        {
-            _subject.Suppress(1000);
-            if (mute != _isMuted)
-            {
-                _imageButton.PerformClick();
-            }
         }
 
         public IDisposable Subscribe(IObserver<Tuple<float, bool>> observer)


### PR DESCRIPTION
All of the class construction is done from the Activity when the audio controller is created. Reduces coupling by injecting dependencies into the builder classes. These builder classes are then used to generate new components. Fixes #20 the image button no longer vibrates the device.