### PR TITLE
Fix bug in connection startup.

### DIFF
--- a/AudiosAmigo.Droid/MainActivity.cs
+++ b/AudiosAmigo.Droid/MainActivity.cs
@@ -72,14 +72,15 @@ namespace AudiosAmigo.Droid
             var handler = new AudioClient(controller);
 
             var client = new TcpClient(ip, port);
-            var communication = new SecureTcpClientCommunication(
+            var communication = new SecureClientCommunication(
                 new TcpClientCommunication(client),
                 new Encrpytion(password, Constants.EncrpytionInitVector));
             var communicator = new Communicator<Command>(
                 communication, NewThreadScheduler.Default);
 
-            communicator.SubscribeOn(NewThreadScheduler.Default).Subscribe(handler);
-            handler.SubscribeOn(NewThreadScheduler.Default).Subscribe(communicator);
+            communicator.Subscribe(handler);
+            handler.Subscribe(communicator);
+            handler.SendGetAllDevices();
         }
     }
 }

--- a/AudiosAmigo.Windows/AudiosAmigo.Windows.csproj
+++ b/AudiosAmigo.Windows/AudiosAmigo.Windows.csproj
@@ -104,6 +104,7 @@
     <Compile Include="AudioProcessController.cs" />
     <Compile Include="AudioServer.cs" />
     <Compile Include="ClientAcceptor.cs" />
+    <Compile Include="NetworkSessionManager.cs" />
     <Compile Include="SettingsForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/AudiosAmigo.Windows/NetworkSessionManager.cs
+++ b/AudiosAmigo.Windows/NetworkSessionManager.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace AudiosAmigo.Windows
+{
+    public class NetworkSessionManager : IDisposable
+    {
+        private readonly CompositeDisposable _generalSubscriptions = new CompositeDisposable();
+
+        private readonly CompositeDisposable _sessionSubscriptions = new CompositeDisposable();
+
+        private int _counter;
+
+        public NetworkSessionManager(int serverTcpListenerPort, string password)
+        {
+            Refresh(serverTcpListenerPort, password);
+        }
+
+        public void Refresh(int serverTcpListenerPort, string password)
+        {
+            _generalSubscriptions.Clear();
+            _sessionSubscriptions.Clear();
+            _generalSubscriptions.Add(UdpUtil.ReceivePortInfo(Constants.ServerBroadcastListenerPort)
+                .Subscribe(UdpUtil.IntWriter(serverTcpListenerPort)));
+
+            var tcpCommunication = ClientAcceptor.From(serverTcpListenerPort)
+                .Select(client => new SecureClientCommunication(
+                    new TcpClientCommunication(client),
+                    new Encrpytion(password, Constants.EncrpytionInitVector)));
+            _generalSubscriptions.Add(tcpCommunication.Subscribe(SetSession));
+        }
+
+        private void SetSession(INetworkCommunication communication)
+        {
+            _sessionSubscriptions.Clear();
+            _sessionSubscriptions.Add(communication);
+            var communicator = new Communicator<Command>(communication, NewThreadScheduler.Default);
+            var handler = new AudioServer(new AudioController());
+            _sessionSubscriptions.Add(communicator.Subscribe(handler.OnNext, 
+                Console.WriteLine, () => Console.WriteLine("communicator to handler complete")));
+            _sessionSubscriptions.Add(handler.Subscribe(communicator.OnNext, 
+                Console.WriteLine, () => Console.WriteLine("handler to communicator complete")));
+            Console.WriteLine($"Client No {_counter++}, Created.");
+        }
+
+        public void Dispose()
+        {
+            _sessionSubscriptions.Dispose();
+            _generalSubscriptions.Dispose();
+        }
+    }
+}

--- a/AudiosAmigo.Windows/Program.cs
+++ b/AudiosAmigo.Windows/Program.cs
@@ -13,15 +13,12 @@ namespace AudiosAmigo.Windows
         [STAThread]
         public static void Main()
         {
-            var subscriptions = new CompositeDisposable
-            {
-                Begin(AppSettings.Port, AppSettings.Password)
-            };
+            var sessionManager = new NetworkSessionManager(AppSettings.Port, AppSettings.Password);
             var systemTrayIcon = new SystemTrayIcon();
             var settingsForm = new SettingsForm();
             systemTrayIcon.ExitClicked += (sender, args) =>
             {
-                subscriptions.Dispose();
+                sessionManager.Dispose();
                 Application.Exit();
                 Environment.Exit(0);
             };
@@ -31,45 +28,9 @@ namespace AudiosAmigo.Windows
             };
             settingsForm.SettingsApplied += (sender, args) =>
             {
-                subscriptions.Clear();
-                subscriptions.Add(Begin(AppSettings.Port, AppSettings.Password));
+                sessionManager.Refresh(AppSettings.Port, AppSettings.Password);
             };
             Application.Run();
-        }
-
-        public static IDisposable Begin(int serverTcpListenerPort, string password)
-        {
-            var counter = 0;
-            return new CompositeDisposable
-            {
-                UdpUtil.ReceivePortInfo(Constants.ServerBroadcastListenerPort)
-                    .Subscribe(UdpUtil.IntWriter(serverTcpListenerPort)),
-
-                ClientAcceptor.From(serverTcpListenerPort)
-                    .Select(client => new SecureTcpClientCommunication(
-                        new TcpClientCommunication(client), new Encrpytion(password, Constants.EncrpytionInitVector)))
-                    .Scan((INetworkCommunication) null, (last, next) =>
-                    {
-                        last?.Close();
-                        return next;
-                    })
-                    .Select(communication => new Communicator<Command>(communication, NewThreadScheduler.Default))
-                    .Select(communicator =>
-                    {
-                        var handler = new AudioServer(new AudioController());
-                        return new CompositeDisposable
-                        {
-                            communicator.SubscribeOn(NewThreadScheduler.Default).Subscribe(handler),
-                            handler.SubscribeOn(NewThreadScheduler.Default).Subscribe(communicator)
-                        };
-                    })
-                    .Scan((IDisposable) null, (last, next) =>
-                    {
-                        last?.Dispose();
-                        return next;
-                    })
-                    .Subscribe(_ => Console.WriteLine($"Client No {counter++}, Created."))
-            };
         }
     }
 }

--- a/AudiosAmigo/AudiosAmigo.projitems
+++ b/AudiosAmigo/AudiosAmigo.projitems
@@ -14,7 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Encrpytion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PasswordUtil.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)SecureTcpClientCommunication.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SecureClientCommunication.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SupressSubject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UdpUtil.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Command.cs" />

--- a/AudiosAmigo/INetworkCommunication.cs
+++ b/AudiosAmigo/INetworkCommunication.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace AudiosAmigo
 {
-    public interface INetworkCommunication
+    public interface INetworkCommunication : IDisposable
     {
         string Receive();
 
@@ -9,7 +11,5 @@ namespace AudiosAmigo
         void Send(string text);
 
         void SendBytes(byte[] buffer);
-
-        void Close();
     }
 }

--- a/AudiosAmigo/SecureClientCommunication.cs
+++ b/AudiosAmigo/SecureClientCommunication.cs
@@ -1,14 +1,12 @@
-﻿using System.Net.Sockets;
-
-namespace AudiosAmigo
+﻿namespace AudiosAmigo
 {
-    public class SecureTcpClientCommunication : INetworkCommunication
+    public class SecureClientCommunication : INetworkCommunication
     {
         private readonly Encrpytion _encrpytion;
 
-        private readonly TcpClientCommunication _communication;
+        private readonly INetworkCommunication _communication;
 
-        public SecureTcpClientCommunication(TcpClientCommunication communication, Encrpytion encrpytion)
+        public SecureClientCommunication(INetworkCommunication communication, Encrpytion encrpytion)
         {
             _encrpytion = encrpytion;
             _communication = communication;
@@ -34,9 +32,9 @@ namespace AudiosAmigo
             _communication.SendBytes(_encrpytion.Encrypt(buffer));
         }
 
-        public void Close()
+        public void Dispose()
         {
-            _communication.Close();
+            _communication.Dispose();
         }
     }
 }

--- a/AudiosAmigo/TcpClientCommunication.cs
+++ b/AudiosAmigo/TcpClientCommunication.cs
@@ -62,7 +62,7 @@ namespace AudiosAmigo
             _stream.Write(buffer, 0, buffer.Length);
         }
 
-        public void Close()
+        public void Dispose()
         {
             _stream.Close();
         }


### PR DESCRIPTION
I was seen that initial messages between the server and client were not properly being sent. This caused the client to sometimes miss the initial `DeviceUpdate` command, therefore not creating a device page and not requesting images. The connection startup has been cleaned up and now uses a proper disposable inside of the `Communicator` ctor.